### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,10 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   def create
     @item = Item.new(item_params)
     if @item.save

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,12 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
+  def edit
+  end
+
+  def destroy
+  end
+
   def show
     @item = Item.find(params[:id])
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
 
   def index
     @items = Item.all.order(created_at: :desc)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,4 +17,9 @@ class User < ApplicationRecord
     validates :name_sei_kana, presence: true
     validates :name_mei_kana, presence: true
   end
+
+  def name
+    "#{name_sei} #{name_mei}" # ユーザーの姓と名を結合して名前を返す例
+  end
+  
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,5 +21,4 @@ class User < ApplicationRecord
   def name
     "#{name_sei} #{name_mei}" # ユーザーの姓と名を結合して名前を返す例
   end
-  
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,7 +132,7 @@
 
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to item_path(item.id) do %>
               <div class='item-img-content'>
                 <% if item.image.attached? %>
                   <%= image_tag item.image, class: "item-img" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -6,8 +6,19 @@
     <h2 class="name">
       <%= "商品名" %>
     </h2>
+
+      <%= link_to item_path(@item.id) do %>
+              <% if @item.image.attached? %>
+                <%= image_tag @item.image, class: "item-img" %>
+              <% end %>
+      <% end %>
+
+
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+
+      <%# 商品がない場合に示すサンプル画像 %>
+      <%#= image_tag "item-sample.png" ,class:"item-box-img" %>
+
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -36,6 +47,12 @@
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
+      <%= link_to item_path(@item.id) do %>
+              <% if @item.image.attached? %>
+                <%= image_tag @item.image, class: "item-img" %>
+              <% end %>
+      <% end %>
+
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
     </div>
@@ -43,27 +60,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user_id %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= Category.find(@item.category_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= Condition.find(@item.condition_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= Charge.find(@item.charge_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= Region.find(@item.region_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= Estimate.find(@item.estimate_id).name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,42 +1,27 @@
 <%= render "shared/header" %>
 
 <div class="item-show">
-    <div class="item-box">
+  <div class="item-box">
       <h2 class="name">
         <%= @item.name %>
       </h2>
 
-      <%= link_to item_path(@item.id) do %>
+      <div class="item-img-content">
+        <%= link_to item_path(@item.id) do %>
               <% if @item.image.attached? %>
                 <%= image_tag @item.image, class: "item-img" %>
               <% end %>
-          <div class="item-img-content">
-      <% end %>
+        <% end %>
 
-      <div class="item-price-box">
-        <span class="item-price">
-        <%= "¥ #{@item.price}" %>
-        </span>
-        <span class="item-postage">
-          <%= Charge.find(@item.charge_id).name %>
-        </span>
+        <div class="item-price-box">
+          <span class="item-price">
+          <%= "¥ #{@item.price}" %>
+          </span>
+          <span class="item-postage">
+            <%= Charge.find(@item.charge_id).name %>
+          </span>
+        </div>
       </div>
-    </div>
-
-
-  <%# if '◆◆◆商品は購入済みである。◆◆◆'%>
-    <%# ◆◆◆購入済みであればSoldoutを表記する◆◆◆'%>
-
-    <%# <div class="item-img-content"> %>
-      <%# <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <%# <div class="sold-out"> %>
-        <%# <span>Sold Out!!</span> %>
-      <%# </div> %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
-    <%# </div> %>
-
-  <%# end '◆◆◆商品が購入済みかどうかが判断された。◆◆◆'%>
 
 
     <% if user_signed_in? %>
@@ -48,7 +33,7 @@
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>
     <% else %>
-  <% end %>
+    <% end %>
 
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -60,7 +60,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.user_id %></td>
+          <td class="detail-value"><%= User.find(@item.user_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,6 +1,5 @@
 <%= render "shared/header" %>
 
-  <%# 商品の概要 %>
 <div class="item-show">
     <div class="item-box">
       <h2 class="name">
@@ -25,7 +24,8 @@
     </div>
 
 
-  <%# if '◆◆◆商品は購入済みである◆◆◆'%>
+  <%# if '◆◆◆商品は購入済みである。◆◆◆'%>
+    <%# ◆◆◆購入済みであればSoldoutを表記する◆◆◆'%>
 
     <%# <div class="item-img-content"> %>
       <%# <%= image_tag "item-sample.png" ,class:"item-box-img" %>
@@ -93,7 +93,6 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
 
   <div class="comment-box">
     <form>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,9 +26,9 @@
 
     <% if user_signed_in? %>
       <% if current_user.id == @item.user_id %>
-        <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -47,12 +47,6 @@
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
-      <%= link_to item_path(@item.id) do %>
-              <% if @item.image.attached? %>
-                <%= image_tag @item.image, class: "item-img" %>
-              <% end %>
-      <% end %>
-
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,19 +4,26 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
 
       <%= link_to item_path(@item.id) do %>
               <% if @item.image.attached? %>
                 <%= image_tag @item.image, class: "item-img" %>
               <% end %>
+          <div class="item-img-content">
       <% end %>
 
+    <div class="item-price-box">
+      <span class="item-price">
+      <%= "¥ #{@item.price}" %>
+      </span>
+      <span class="item-postage">
+        <%= Charge.find(@item.charge_id).name %>
+      </span>
+    </div>
 
-    <div class="item-img-content">
-
-      <%# 商品がない場合に示すサンプル画像 %>
+  <%# 商品がない場合に示すサンプル画像、内容 %>
       <%#= image_tag "item-sample.png" ,class:"item-box-img" %>
 
       <%# 商品が売れている場合は、sold outを表示しましょう %>
@@ -25,6 +32,7 @@
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
+
     <div class="item-price-box">
       <span class="item-price">
         ¥ 999,999,999
@@ -33,6 +41,9 @@
         <%= "配送料負担" %>
       </span>
     </div>
+  <%# 商品がない場合に示すサンプル画像、内容 %>
+
+
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,6 +1,5 @@
 <%= render "shared/header" %>
 
-<%# if '◆◆◆商品は販売中である。◆◆◆' %>
 
   <%# 商品の概要 %>
   <div class="item-show">
@@ -27,34 +26,19 @@
     </div>
   </div>
 
-<%# else '◆◆◆商品は売り切れである◆◆◆'%>
-  <%# ▽▽▽ 商品がない場合に示すサンプル画像、内容 ▽▽▽ %>
 
-  <div class="item-box">
-    <h2 class="name">
-      <%= "商品名" %>
-    </h2>
-    <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+  <%# if '◆◆◆商品は購入済みである◆◆◆'%>
+
+    <%# <div class="item-img-content"> %>
+      <%# <%= image_tag "item-sample.png" ,class:"item-box-img" %> %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+      <%# <div class="sold-out"> %>
+        <%# <span>Sold Out!!</span> %>
+      <%# </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
-    </div>
-    <div class="item-price-box">
-      <span class="item-price">
-        ¥ 999,999,999
-      </span>
-      <span class="item-postage">
-        <%= "配送料負担" %>
-      </span>
-    </div>
-  </div>
+    <%# </div> %>
 
-  <%# △△△ 商品がない場合に示すサンプル画像、内容 △△△ %>
-<%# end '◆◆◆商品が売り切れかどうかが判断された。◆◆◆'%>
-
+  <%# end '◆◆◆商品が購入済みかどうかが判断された。◆◆◆'%>
 
 
 <%# if 'ログインしている' %>
@@ -66,6 +50,7 @@
 <%# else ''%>
     <%# ボタンを表示しない %>
 <%# end ''%>
+
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,8 +1,7 @@
 <%= render "shared/header" %>
 
-
   <%# 商品の概要 %>
-  <div class="item-show">
+<div class="item-show">
     <div class="item-box">
       <h2 class="name">
         <%= @item.name %>
@@ -24,13 +23,12 @@
         </span>
       </div>
     </div>
-  </div>
 
 
   <%# if '◆◆◆商品は購入済みである◆◆◆'%>
 
     <%# <div class="item-img-content"> %>
-      <%# <%= image_tag "item-sample.png" ,class:"item-box-img" %> %>
+      <%# <%= image_tag "item-sample.png" ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <%# <div class="sold-out"> %>
         <%# <span>Sold Out!!</span> %>
@@ -41,29 +39,17 @@
   <%# end '◆◆◆商品が購入済みかどうかが判断された。◆◆◆'%>
 
 
-<%# if 'ログインしている' %>
-  <%# if '出品している' %>
-    <%# 商品編集削除ボタン %>
-  <%# else ''%>
-    <%# 商品購入ボタン %>
-  <%# end ''%>
-<%# else ''%>
-    <%# ボタンを表示しない %>
-<%# end ''%>
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user_id %>
+        <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
+      <% else %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <% end %>
+    <% else %>
+  <% end %>
 
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,11 +1,13 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
-<div class="item-show">
-  <div class="item-box">
-    <h2 class="name">
-      <%= @item.name %>
-    </h2>
+<%# if '◆◆◆商品は販売中である。◆◆◆' %>
+
+  <%# 商品の概要 %>
+  <div class="item-show">
+    <div class="item-box">
+      <h2 class="name">
+        <%= @item.name %>
+      </h2>
 
       <%= link_to item_path(@item.id) do %>
               <% if @item.image.attached? %>
@@ -14,25 +16,32 @@
           <div class="item-img-content">
       <% end %>
 
-    <div class="item-price-box">
-      <span class="item-price">
-      <%= "¥ #{@item.price}" %>
-      </span>
-      <span class="item-postage">
-        <%= Charge.find(@item.charge_id).name %>
-      </span>
+      <div class="item-price-box">
+        <span class="item-price">
+        <%= "¥ #{@item.price}" %>
+        </span>
+        <span class="item-postage">
+          <%= Charge.find(@item.charge_id).name %>
+        </span>
+      </div>
     </div>
+  </div>
 
-  <%# 商品がない場合に示すサンプル画像、内容 %>
-      <%#= image_tag "item-sample.png" ,class:"item-box-img" %>
+<%# else '◆◆◆商品は売り切れである◆◆◆'%>
+  <%# ▽▽▽ 商品がない場合に示すサンプル画像、内容 ▽▽▽ %>
 
+  <div class="item-box">
+    <h2 class="name">
+      <%= "商品名" %>
+    </h2>
+    <div class="item-img-content">
+      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
-
     <div class="item-price-box">
       <span class="item-price">
         ¥ 999,999,999
@@ -41,9 +50,22 @@
         <%= "配送料負担" %>
       </span>
     </div>
-  <%# 商品がない場合に示すサンプル画像、内容 %>
+  </div>
+
+  <%# △△△ 商品がない場合に示すサンプル画像、内容 △△△ %>
+<%# end '◆◆◆商品が売り切れかどうかが判断された。◆◆◆'%>
 
 
+
+<%# if 'ログインしている' %>
+  <%# if '出品している' %>
+    <%# 商品編集削除ボタン %>
+  <%# else ''%>
+    <%# 商品購入ボタン %>
+  <%# end ''%>
+<%# else ''%>
+    <%# ボタンを表示しない %>
+<%# end ''%>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
@@ -59,7 +81,7 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -101,9 +101,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+
+  <a href="#" class="another-item"><%= Category.find(@item.category_id).name %>をもっと見る</a>
+
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :destroy]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")


### PR DESCRIPTION
# What
　・商品詳細表示機能を実装した。
　・「売却済み」以外の機能を実装した。

# Why
　実装結果として以下の動画を提示する。

　ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
　　https://gyazo.com/65026e2e9cde60c75daa9b509b0649b1

　ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
　　https://gyazo.com/12127efc094e88fc6b6adc322240e52e

　ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
　　未実装

　ログアウト状態で、商品詳細ページへ遷移した動画
　　https://gyazo.com/b740315f65e19684bf4f09d32e23148d